### PR TITLE
[Draft] Handle special case where first byte of stream is > 17, indicating literal data to copy

### DIFF
--- a/test/DecompressorTest.cs
+++ b/test/DecompressorTest.cs
@@ -44,6 +44,7 @@ namespace lzo.net.test
             {"world95.txt", "9b43f25ddee11084ba66f7e638642e85"},
             {"A10.jpg", "735ba97200122210ee7c3faaa98a701a"},
             {"AcroRd32.exe", "9e0d2a448501bf430984ba041e6658f4"},
+            {"compressed_data.bin", "bff3b4c25f19ab44530c3cd25888c002"},
             {"english.dic", "930f84ac31e3bd1802d9aba392c475a0"},
             {"FlashMX.pdf", "8bf62ff2eebde7f3f132c6f362328dba"},
             {"FP.LOG", "059d1d86734a3478c29e862bf2026684"},

--- a/test/data/compressed_data.bin.lzo
+++ b/test/data/compressed_data.bin.lzo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95998b14be15192cebdf0c2a8e56c2a935c8003843165e74a4bba4eaef568d7c
+size 86


### PR DESCRIPTION
This is NOT a complete fix, but it happens to work for the specific data I'm decompressing. Aside from probably being badly written, there's a case not handled. I'll add a comment inline to indicate it.